### PR TITLE
Add silent mode

### DIFF
--- a/plugin.video.placenta/default.py
+++ b/plugin.video.placenta/default.py
@@ -479,6 +479,10 @@ elif action == 'moviesToLibrary':
     from resources.lib.modules import libtools
     libtools.libmovies().range(url)
 
+elif action == 'moviesToLibrarySilent':
+    from resources.lib.modules import libtools
+    libtools.libmovies().silent(url)
+
 elif action == 'tvshowToLibrary':
     from resources.lib.modules import libtools
     libtools.libtvshows().add(tvshowtitle, year, imdb, tvdb)
@@ -486,6 +490,10 @@ elif action == 'tvshowToLibrary':
 elif action == 'tvshowsToLibrary':
     from resources.lib.modules import libtools
     libtools.libtvshows().range(url)
+
+elif action == 'tvshowsToLibrarySilent':
+    from resources.lib.modules import libtools
+    libtools.libtvshows().silent(url)
 
 elif action == 'updateLibrary':
     from resources.lib.modules import libtools

--- a/script.module.placenta/lib/resources/lib/modules/libtools.py
+++ b/script.module.placenta/lib/resources/lib/modules/libtools.py
@@ -122,7 +122,8 @@ class libmovies:
 
 
     def add(self, name, title, year, imdb, tmdb, range=False):
-        if not control.condVisibility('Window.IsVisible(infodialog)') and not control.condVisibility('Player.HasVideo'):
+        if not control.condVisibility('Window.IsVisible(infodialog)') and not control.condVisibility('Player.HasVideo')\
+                and self.silentDialog is False:
             control.infoDialog(control.lang(32552).encode('utf-8'), time=10000000)
             self.infoDialog = True
 
@@ -285,6 +286,29 @@ class libtvshows:
 
         if self.library_setting == 'true' and not control.condVisibility('Library.IsScanningVideo') and files_added > 0:
             control.execute('UpdateLibrary(video)')
+
+    def silent(self, url):
+        control.idle()
+
+        if not control.condVisibility('Window.IsVisible(infodialog)') and not control.condVisibility('Player.HasVideo'):
+            control.infoDialog(control.lang(32552).encode('utf-8'), time=10000000)
+            self.infoDialog = True
+            self.silentDialog = True
+
+        from resources.lib.indexers import movies
+        items = movies.movies().get(url, idx=False)
+        if items == None: items = []
+
+        for i in items:
+            try:
+                if xbmc.abortRequested == True: return sys.exit()
+                self.add('%s (%s)' % (i['title'], i['year']), i['title'], i['year'], i['imdb'], i['tmdb'], range=True)
+            except:
+                pass
+
+        if self.infoDialog == True:
+            self.silentDialog = False
+            control.infoDialog("Trakt Movies Sync Complete", time=1)
 
 
     def range(self, url):


### PR DESCRIPTION
Automatically add new movies or shows from a trakt list to library, via script or cron job. No need to press confirm. Ideal for headless instances of Kodi.

**Usage**:

Movies:
`kodi-send --action "RunPlugin(plugin://plugin.video.placenta/?action=moviesToLibrarySilent&url=http%3A%2F%2Fapi.trakt.tv%2Fusers%2Fme%2Flists%2Fmovie-queue%2Fitems)"`

Shows:
`kodi-send --action "RunPlugin(plugin://plugin.video.placenta/?action=tvshowsToLibrarySilent&url=http%3A%2F%2Fapi.trakt.tv%2Fusers%2Fme%2Flists%2Fshow-queue%2Fitems)"`