### PR TITLE
watchseries scraper tweaks and improvements

### DIFF
--- a/script.module.placenta/lib/resources/lib/sources/en/watchseries.py
+++ b/script.module.placenta/lib/resources/lib/sources/en/watchseries.py
@@ -52,8 +52,8 @@ class source:
 
 			url = url.encode('utf-8')
 			
-			log_utils.log('\n\n~~~ outgoing tvshow() url')
-			log_utils.log(url)
+			#log_utils.log('\n\n~~~ outgoing tvshow() url')
+			#log_utils.log(url)
 			
 			# returned 'url' format like: /serie/x_files 
 			return url
@@ -64,12 +64,12 @@ class source:
 	def episode(self, url, imdb, tvdb, title, premiered, season, episode):
 		try:
 			if url == None: return
-			log_utils.log('\n\n~~~ incomingish episode() url')
-			log_utils.log(url)
+			#log_utils.log('\n\n~~~ incomingish episode() url')
+			#log_utils.log(url)
 
 			url = urlparse.urljoin(self.base_link, url)
-			log_utils.log('\n\n~~~ baselink-joined url')
-			log_utils.log(url)
+			#log_utils.log('\n\n~~~ baselink-joined url')
+			#log_utils.log(url)
 			
 			
 			# req page 3 times to workaround their BS random 404's
@@ -101,7 +101,7 @@ class source:
 			# firstly, try to match YYYY-MM-DD listed in ep listing
 			#  (this should (?) be more reliable than season/ep)
 			try:	
-				log_utils.log('\n\n~~~ Attempting: find ep by air-date')
+				#log_utils.log('\n\n~~~ Attempting: find ep by air-date')
 				
 				# iterate through all 'a', from 'items' above...
 				# grab all links that contain matching season/ep...
@@ -114,7 +114,7 @@ class source:
 			
 			# if no url match by date, continue to try by season/ep#
 			if url == None:
-				log_utils.log('\n\n~~~ Attempting: (url==None) match by season/ep')
+				#log_utils.log('\n\n~~~ Attempting: (url==None) match by season/ep')
 			
 				# iterate through all 'a', from 'items' above...
 				# grab all links that contain matching season/ep...
@@ -123,8 +123,8 @@ class source:
 			
 			
 			url = url.encode('utf-8')
-			log_utils.log('\n\n~~~ outgoing episode() url')
-			log_utils.log(url)
+			#log_utils.log('\n\n~~~ outgoing episode() url')
+			#log_utils.log(url)
 			
 			# returned 'url' format like: /episode/x_files_s4_e1.html
 			return url
@@ -134,8 +134,8 @@ class source:
 
 	def sources(self, url, hostDict, hostprDict):
 	
-		log_utils.log('\n\n~~~ incoming sources() url')
-		log_utils.log(url)
+		#log_utils.log('\n\n~~~ incoming sources() url')
+		#log_utils.log(url)
 	
 		try:
 			sources = []


### PR DESCRIPTION
Did a couple useful things:
1) tweaked max-attempts for requests
2) try to find by air-date AND by s00e00
3) debrid users get debrid hosts preferred at no client.request() cost

I'm sure someone (probably *anyone*) could do a better job with the code from the third thing, but I don't have any good idea of how it should be cleaned up. seems to work nicely though for my realdebrid. since watchseries totally obfuscates every single host url by forcing an additional page load, getting links is network costly but they do state the host name before the obfuscation page, so I loop through just the host names and check if they're debridable